### PR TITLE
Draw board

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,15 @@ Then do the following (this will help later):
 
     $ echo "export VENV=~/<ENVNAME>/bin" >> ~/.bashrc
 
+### If you're not on the Pi
+Then you won't have access to the actual HERA board, and you'll want to run the games
+on your own screen using pygame. Then install like this:
+
+    $ pip install -e .[screen]
+
+Most scripts come with a command-line option `--use-screen` that will use the screen
+simulator rather than the actual board.
+
 ## How to run our test scripts
 
 ### If you're on the Raspberry-Pi

--- a/setup.cfg
+++ b/setup.cfg
@@ -54,7 +54,8 @@ dev =
 [options.entry_points]
 # All actual games (and simulations) should be defined here
 console_scripts =
-     random_walk = hera_display_games.random_walk:main
+    random_walk = hera_display_games.random_walk:main
+    count_pixels = hera_display_games.count_pixels:main
 
 [test]
 # py.test options when running `python setup.py test`

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,6 +44,8 @@ exclude =
     tests
 
 [options.extras_require]
+screen =
+    pygame
 testing =
     pytest
     pytest-cov

--- a/src/hera_display_games/core/map_dict.py
+++ b/src/hera_display_games/core/map_dict.py
@@ -352,3 +352,5 @@ led_map = {
     (20, 20): 210,
     (21, 20): "dead",
 }
+
+reverse_led_map = {val: key for key, val in led_map.items() if val != "dead"}

--- a/src/hera_display_games/core/mechanics.py
+++ b/src/hera_display_games/core/mechanics.py
@@ -9,7 +9,12 @@ import math
 import time
 from abc import ABC, abstractmethod
 
-import pygame
+try:
+    import pygame
+
+    HAVE_PYGAME = True
+except ImportError:
+    HAVE_PYGAME = False
 
 from . import map_dict
 
@@ -209,5 +214,12 @@ class Board(_BoardBase):
 
 
 class VirtualBoard(_BoardBase):
+    def __init__(self, *args, **kwargs):
+        if not HAVE_PYGAME:
+            raise ImportError(
+                "You need to have the pygame package installed to use the virtual board! You "
+                "can still use the default Board."
+            )
+
     def make_strip(self):
         return PyGameStrip()

--- a/src/hera_display_games/core/mechanics.py
+++ b/src/hera_display_games/core/mechanics.py
@@ -206,6 +206,7 @@ class Board(_BoardBase):
                 "You need to have the neopixel package installed to use the default board! You "
                 "can still use the VirtualBoard."
             )
+        super().__init__(*args, **kwargs)
 
     def make_strip(self):
         return neopixel.Adafruit_NeoPixel(
@@ -220,6 +221,7 @@ class VirtualBoard(_BoardBase):
                 "You need to have the pygame package installed to use the virtual board! You "
                 "can still use the default Board."
             )
+        super().__init__(*args, **kwargs)
 
     def make_strip(self):
         return PyGameStrip()

--- a/src/hera_display_games/count_pixels/__init__.py
+++ b/src/hera_display_games/count_pixels/__init__.py
@@ -1,0 +1,36 @@
+#! /usr/bin/env python
+# -*- coding: utf-8 -*-
+"""A simple simulation of a random walk"""
+import click
+from hera_display_games.core import mechanics, map_dict
+import time
+import random
+
+
+@click.command()
+@click.option("-s", "--speed", type=float, default=1, help="Speed of sprite")
+@click.option(
+    "-x",
+    "-X",
+    "--use-screen/--use-board",
+    default=False,
+    help="whether to use the physical HERA board",
+)
+def main(speed, use_screen):
+    if not 1 <= speed <= 100:
+        raise ValueError("speed must be between 1 and 100")
+
+    sprite = mechanics.Sprite([0, 0])
+
+    if not use_screen:
+        my_board = mechanics.Board(sprites=[sprite])
+    else:
+        my_board = mechanics.VirtualBoard(sprites=[sprite])
+
+    my_board.draw()
+
+    max_pixel = max(map_dict.reverse_led_map.keys())
+    for i in range(max_pixel):
+        sprite.goto(i)
+        my_board.draw()
+        time.sleep(1.0 / speed)

--- a/src/hera_display_games/random_walk/__init__.py
+++ b/src/hera_display_games/random_walk/__init__.py
@@ -10,7 +10,14 @@ import random
 @click.command()
 @click.option("-s", "--speed", type=float, default=1, help="Speed of sprite")
 @click.option("-n", "--nsprites", type=int, default=1, help="number of sprites")
-def main(speed, nsprites):
+@click.option(
+    "-x",
+    "-X",
+    "--use-screen/--use-board",
+    default=False,
+    help="whether to use the physical HERA board",
+)
+def main(speed, nsprites, use_screen):
     if not 1 <= nsprites <= 6:
         raise ValueError("nsprites must be between 1 and 6")
 
@@ -21,7 +28,11 @@ def main(speed, nsprites):
     for i in range(nsprites):
         my_sprites.append(mechanics.Sprite([0, i]))
 
-    my_board = mechanics.Board(sprites=my_sprites)
+    if not use_screen:
+        my_board = mechanics.Board(sprites=my_sprites)
+    else:
+        my_board = mechanics.VirtualBoard(sprites=my_sprites)
+
     my_board.draw()
 
     directions = ["r", "l", "dl", "dr", "ur", "ul"]


### PR DESCRIPTION
Adds a new class to enable drawing a mock board with pygame, rather than using the actual physical board. Maintains the same API as the actual board.

Fixes #10 